### PR TITLE
New way to pass ENVIRONMENT VARIABLES to runtime, to control DEBUG ou…

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,17 +1,35 @@
 ## REFERENCES:
 ## (1) Passing environment variable with fallback value to Makefile:
 ##    https://stackoverflow.com/a/70772707/6366150
-##
+## (2) Export environment variables inside "make environment"
+##		https://stackoverflow.com/a/49524393/6366150
+## (3) Uppercase to lowercase and vice versa
+##		https://community.unix.com/t/uppercase-to-lowercase-and-vice-versa/285278/6
+## (4) How do I trim leading and trailing whitespace from each line of some output?
+## 		https://unix.stackexchange.com/a/279222/233927
+############################################################################
 
-LOG_LEVEL := "info" ## (1) ## info | debug
-BRUTEFORCE := "false" # true | false
+## (1) ## Allowed values: info | warn | error | debug
+LOG_LEVEL ?= info
+## (3) (4)
+LOG_LEVEL :=$(shell echo '${LOG_LEVEL}'| tr '[:lower:]' '[:upper:]'| tr -d '[:blank:]')
 
+## (1) ## Allowed values: true | false
+BRUTEFORCE ?= false
+## (3) (4)
+BRUTEFORCE :=$(shell echo '${BRUTEFORCE}'| tr '[:lower:]' '[:upper:]'| tr -d '[:blank:]')
+
+# Package Manager
 NPM=npm
 NPM_PKG_LIST=$(npm list)
 NPM_UPDATABLE_MODULES = $(shell npm outdated | cut -d' ' -f 1 | sed '1d' | xargs -I '$$' echo '$$@latest' | xargs echo )
 
+# DOCKER
+BUILDKIT_PROGRESS=plain
+
 .MAIN: test
 .PHONY: all clean dependencies help list test outdated
+.EXPORT_ALL_VARIABLES: # (2)
 
 help: list
 
@@ -22,7 +40,7 @@ env:
 	@echo "################################################################################"
 	@echo "## Environment: ################################################################"
 	@echo "################################################################################"
-	@printenv
+	@printenv | grep -E "LOG_LEVEL|BRUTEFORCE|BUILDKIT_PROGRESS"
 	@echo "################################################################################"
 
 clean:
@@ -50,13 +68,13 @@ outdated:
 update: dependencies outdated
 	npm install $(NPM_UPDATABLE_MODULES)
 
-docker/build:
-	BUILDKIT_PROGRESS=plain docker-compose --profile testing build
+docker/compose-build: env
+	docker-compose --profile testing build
 
-docker/rebuild:
-	BUILDKIT_PROGRESS=plain docker-compose --profile testing build --no-cache
+docker/compose-rebuild: env
+	docker-compose --profile testing build --no-cache
 
-docker/compose-run: docker/build
-	docker-compose --profile testing run --rm projecteuler-js make test -e LOG_LEVEL=$(LOG_LEVEL) -e BRUTEFORCE=$(BRUTEFORCE)
+docker/compose-run: env docker/build
+	docker-compose --profile testing run --rm projecteuler-js make test
 
 all: env dependencies test


### PR DESCRIPTION
…tput and enable/disable BRUTEFORCE test, with fallback values.

REFERENCES:
 * Define a Makefile variable using a ENV variable or a default value https://stackoverflow.com/a/24263397/6366150
 * Docker compose .env default with fallback https://stackoverflow.com/a/70772707/6366150
 * Export environment variables inside "make environment" https://stackoverflow.com/a/49524393/6366150
 * Uppercase to lowercase and vice versa https://community.unix.com/t/uppercase-to-lowercase-and-vice-versa/285278/6
 * How do I trim leading and trailing whitespace from each line of some output? https://unix.stackexchange.com/a/279222/233927