### PR TITLE
New way to pass ENVIRONMENT VARIABLES to runtime, to control DEBUG ou…

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -74,7 +74,7 @@ docker/compose-build: env
 docker/compose-rebuild: env
 	docker-compose --profile testing build --no-cache
 
-docker/compose-run: env docker/build
+docker/compose-run: docker/compose-build
 	docker-compose --profile testing run --rm projecteuler-js make test
 
 all: env dependencies test


### PR DESCRIPTION
…tput and enable/disable BRUTEFORCE test, with fallback values.

REFERENCES:
 * Define a Makefile variable using a ENV variable or a default value https://stackoverflow.com/a/24263397/6366150
 * Docker compose .env default with fallback https://stackoverflow.com/a/70772707/6366150
 * Export environment variables inside "make environment" https://stackoverflow.com/a/49524393/6366150
 * Uppercase to lowercase and vice versa https://community.unix.com/t/uppercase-to-lowercase-and-vice-versa/285278/6
 * How do I trim leading and trailing whitespace from each line of some output? https://unix.stackexchange.com/a/279222/233927